### PR TITLE
Fixes #317 Import default recipe in apache_conf definition

### DIFF
--- a/definitions/apache_conf.rb
+++ b/definitions/apache_conf.rb
@@ -18,6 +18,8 @@
 #
 
 define :apache_conf, :enable => true do
+  include_recipe 'apache2::default'
+
   conf_name = "#{params[:name]}.conf"
   params[:conf_path] = params[:conf_path] || "#{node['apache']['dir']}/conf-available"
 

--- a/definitions/apache_mod.rb
+++ b/definitions/apache_mod.rb
@@ -18,6 +18,8 @@
 #
 
 define :apache_mod do
+  include_recipe 'apache2::default'
+
   template "#{node['apache']['dir']}/mods-available/#{params[:name]}.conf" do
     source "mods/#{params[:name]}.conf.erb"
     mode '0644'


### PR DESCRIPTION
If the apache2::default recipe is not included in definitions where
notifications are raised against the apache2 service then an error can
occur because the service is not defined. That forces the responsibility
for including the default recipe onto the user. By including the
default recipe into all the definitions they become more fault tolerant
and so more useable.