### PR TITLE
Add attribute for default site port

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -251,6 +251,7 @@ default['apache']['keepalivetimeout']  = 5
 default['apache']['locale'] = 'C'
 default['apache']['sysconfig_additional_params'] = {}
 default['apache']['default_site_enabled'] = false
+default['apache']['default_site_port']    = '80'
 
 # Security
 default['apache']['servertokens']    = 'Prod'

--- a/templates/default/default-site.conf.erb
+++ b/templates/default/default-site.conf.erb
@@ -1,4 +1,4 @@
-<VirtualHost *:80>
+<VirtualHost *:<%= node['apache']['default_site_port'] %>>
   ServerAdmin <%= node['apache']['contact'] %>
 
   DocumentRoot <%= node['apache']['docroot_dir'] %>/


### PR DESCRIPTION
The port for the default site should arguably be an attribute since currently if the default site is enabled but the listen_ports array doesn't contain port 80 then apache will be in a mis-configured state.