### PR TITLE
Correct default_site name attribute in not_if guards

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,13 +33,13 @@ end
 %w(default default.conf 000-default 000-default.conf).each do |site|
   link "#{node['apache']['dir']}/sites-enabled/#{site}" do
     action :delete
-    not_if  { site == node['default_site_name'] }
+    not_if  { site == node['apache']['default_site_name'] }
   end
 
   file "#{node['apache']['dir']}/sites-available/#{site}" do
     action :delete
     backup false
-    not_if  { site == node['default_site_name'] }
+    not_if  { site == node['apache']['default_site_name'] }
   end
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,13 +33,13 @@ end
 %w(default default.conf 000-default 000-default.conf).each do |site|
   link "#{node['apache']['dir']}/sites-enabled/#{site}" do
     action :delete
-    not_if  { site == node['apache']['default_site_name'] }
+    not_if { site == "#{node['apache']['default_site_name']}.conf" && node['apache']['default_site_enabled'] }
   end
 
   file "#{node['apache']['dir']}/sites-available/#{site}" do
     action :delete
     backup false
-    not_if  { site == node['apache']['default_site_name'] }
+    not_if { site == "#{node['apache']['default_site_name']}.conf" && node['apache']['default_site_enabled'] }
   end
 end
 


### PR DESCRIPTION
https://github.com/svanzoest-cookbooks/apache2/commit/4aa5d2b7bc9487dc450f70adaded1f5a83356145 introduced not_if guards to the default site file and link deletion but used `node['default_site_name']` instead of `node['apache']['default_site_name']`