### PR TITLE
Conditionally create default_site web_app

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -192,9 +192,11 @@ node['apache']['default_modules'].each do |mod|
   include_recipe "apache2::#{module_recipe_name}"
 end
 
-web_app node['apache']['default_site_name'] do
-  template 'default-site.conf.erb'
-  enable node['apache']['default_site_enabled']
+if node['apache']['default_site_enabled']
+  web_app node['apache']['default_site_name'] do
+    template 'default-site.conf.erb'
+    enable node['apache']['default_site_enabled']
+  end
 end
 
 service 'apache2' do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -184,13 +184,8 @@ describe 'apache2::default' do
             expect(portsconf).to_not notify('service[apache2]').to(:reload).immediately
           end
 
-          it "creates #{property[:apache][:dir]}/sites-available/#{property[:apache][:default_site_name]}.conf" do
-            expect(chef_run).to create_template("#{property[:apache][:dir]}/sites-available/#{property[:apache][:default_site_name]}.conf").with(
-              :source => 'default-site.conf.erb',
-              :owner => 'root',
-              :group => property[:apache][:root_group],
-              :mode =>  '0644'
-            )
+          it "does not create #{property[:apache][:dir]}/sites-available/#{property[:apache][:default_site_name]}.conf" do
+            expect(chef_run).to_not create_template("#{property[:apache][:dir]}/sites-available/#{property[:apache][:default_site_name]}.conf")
           end
 
           if %w(amazon redhat centos fedora suse opensuse).include?(platform)
@@ -260,8 +255,16 @@ describe 'apache2::default' do
             expect(chef_run).to delete_file("#{property[:apache][:dir]}/sites-available/default")
           end
 
+          it "deletes #{property[:apache][:dir]}/sites-available/default.conf" do
+            expect(chef_run).to delete_file("#{property[:apache][:dir]}/sites-available/default.conf")
+          end
+
           it "deletes #{property[:apache][:dir]}/sites-enabled/000-default" do
             expect(chef_run).to delete_link("#{property[:apache][:dir]}/sites-enabled/000-default")
+          end
+
+          it "deletes #{property[:apache][:dir]}/sites-enabled/000-default.conf" do
+            expect(chef_run).to delete_link("#{property[:apache][:dir]}/sites-enabled/000-default.conf")
           end
 
           it 'enables and starts the apache2 service' do


### PR DESCRIPTION
Just noticed another minor issue with the default site, this time with default_site_enabled set to false :smile:. The default_site web_app definition is enabled conditionally but is unconditionally created. With default_site_enabled set to false, currently the default site will be deleted from sites-available but subsequently created by the web_app definition again.

Wrapped the web_app definition with an if statement since it can't take an only_if guard and amended the specs to better reflect the default.rb recipe.
