### PR TITLE
Allow for custom ssl port and use node.default rather than node.set

### DIFF
--- a/attributes/mod_ssl.rb
+++ b/attributes/mod_ssl.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 
+default['apache']['mod_ssl']['port'] = 443
 default['apache']['mod_ssl']['protocol'] = 'All -SSLv2 -SSLv3'
 default['apache']['mod_ssl']['cipher_suite'] = 'EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH:EDH+aRSA:RC4!aNULL!eNULL!LOW!3DES!MD5!EXP!PSK!SRP!DSS'
 default['apache']['mod_ssl']['honor_cipher_order']     = 'On'

--- a/recipes/mod_ssl.rb
+++ b/recipes/mod_ssl.rb
@@ -16,8 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-unless node['apache']['listen_ports'].include?('443')
-  node.set['apache']['listen_ports'] = node['apache']['listen_ports'] + ['443']
+unless node['apache']['listen_ports'].include?(node['apache']['mod_ssl']['port'])
+  node.default['apache']['listen_ports'] = node['apache']['listen_ports'] + [node['apache']['mod_ssl']['port']]
 end
 
 include_recipe 'apache2::default'


### PR DESCRIPTION
* Enable the user to set the default ssl port to something other than 443 if they want.

* Use node.default rather than node.set for adding ssl port as it should be the same precedence as the other ports. No need for a normal setting here

Please let me know what you think about merging these changes. thanks!
