### PR TITLE
SSLStrictSNIVHostCheck breaks RHEL 5

### DIFF
--- a/templates/default/mods/ssl.conf.erb
+++ b/templates/default/mods/ssl.conf.erb
@@ -76,7 +76,7 @@
   #   secure renegotiation protocol. Default: Off
   SSLInsecureRenegotiation <%= node['apache']['mod_ssl']['insecure_renegotiation'] %>
 
-<% unless node['apache']['mod_ssl']['strict_sni_vhost_check'] %>
+<% unless node['apache']['mod_ssl']['strict_sni_vhost_check'] != "Off"%>
   #   Whether to forbid non-SNI clients to access name based virtual hosts.
   #   Default: Off
   SSLStrictSNIVHostCheck <%= node['apache']['mod_ssl']['strict_sni_vhost_check'] %>

--- a/templates/default/mods/ssl.conf.erb
+++ b/templates/default/mods/ssl.conf.erb
@@ -76,7 +76,7 @@
   #   secure renegotiation protocol. Default: Off
   SSLInsecureRenegotiation <%= node['apache']['mod_ssl']['insecure_renegotiation'] %>
 
-<% unless node['apache']['mod_ssl']['strict_sni_vhost_check'] != "Off"%>
+<% unless node['apache']['mod_ssl']['strict_sni_vhost_check'] == "Off"%>
   #   Whether to forbid non-SNI clients to access name based virtual hosts.
   #   Default: Off
   SSLStrictSNIVHostCheck <%= node['apache']['mod_ssl']['strict_sni_vhost_check'] %>

--- a/templates/default/mods/ssl.conf.erb
+++ b/templates/default/mods/ssl.conf.erb
@@ -76,9 +76,11 @@
   #   secure renegotiation protocol. Default: Off
   SSLInsecureRenegotiation <%= node['apache']['mod_ssl']['insecure_renegotiation'] %>
 
+<% unless node['apache']['mod_ssl']['strict_sni_vhost_check'] %>
   #   Whether to forbid non-SNI clients to access name based virtual hosts.
   #   Default: Off
   SSLStrictSNIVHostCheck <%= node['apache']['mod_ssl']['strict_sni_vhost_check'] %>
+<% end %>
 
 <% if node['apache']['version'] == '2.4' -%>
   #   Enable compression on the SSL level


### PR DESCRIPTION
Putting conditional around SSLStrictSNIVHostCheck so it does not appear if it is not turned on. It is turned off by default and if it appears in apache before 2.2.12, it will break the server.