### PR TITLE
Apache2.4 on Amazon linux puts magic in a different place

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -101,8 +101,10 @@ when 'redhat', 'centos', 'scientific', 'fedora', 'amazon', 'oracle'
   default['apache']['cache_dir']   = '/var/cache/httpd'
   default['apache']['run_dir']     = '/var/run/httpd'
   default['apache']['lock_dir']    = '/var/run/httpd'
+  default['apache']['magic_file_dir'] = node['apache']['conf_dir']
   if node['platform'] == 'amazon' && node['apache']['version'] == '2.4'
     default['apache']['devel_package'] = 'httpd24-devel'
+    default['apache']['magic_file_dir'] = '/etc/httpd'
   end
   if node['platform_version'].to_f >= 6
     default['apache']['pid_file'] = '/var/run/httpd/httpd.pid'

--- a/templates/default/mods/mime_magic.conf.erb
+++ b/templates/default/mods/mime_magic.conf.erb
@@ -1,3 +1,3 @@
 <IfModule mod_mime_magic.c>
-  MIMEMagicFile <%= node['apache']['dir'] %>/magic
+  MIMEMagicFile <%= node['magic_file_dir'] %>/magic
 </IfModule>


### PR DESCRIPTION
This fixes magic location on Amazon Linux.