### PR TITLE
Handle alternate shared object filename for Amazon Linux php55/php56

### DIFF
--- a/attributes/mod_php5.rb
+++ b/attributes/mod_php5.rb
@@ -17,3 +17,14 @@
 # limitations under the License.
 
 default['apache']['mod_php5']['install_method'] = 'package'
+default['apache']['mod_php5']['so_filename'] = 'libphp5.so'
+
+case node['platform_family']
+when 'rhel'
+  case node['platform']
+  when 'amazon'
+    if node['apache']['version'] == '2.4'
+      default['apache']['mod_php5']['so_filename'] = 'libphp.so'
+    end
+  end
+end

--- a/recipes/mod_php5.rb
+++ b/recipes/mod_php5.rb
@@ -68,5 +68,5 @@ end
 
 apache_module 'php5' do
   conf true
-  filename 'libphp5.so'
+  filename node['apache']['mod_php5']['so_filename']
 end


### PR DESCRIPTION
This is necessary when using Amazon Linux php55 and php56 packages.