### PR TITLE
Fix bug related with #349

### DIFF
--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -164,13 +164,6 @@ IncludeOptional <%= node['apache']['dir'] %>/mods-enabled/*.conf
 # Include ports listing
 Include <%= node['apache']['dir'] %>/ports.conf
 
-#<Directory /srv/>
-#       Options Indexes FollowSymLinks
-#       AllowOverride None
-#       Require all granted
-#</Directory>
-<% end -%>
-
 #
 # The following directives define some format nicknames for use with
 # a CustomLog directive (see below).


### PR DESCRIPTION
I got a below error message about 3 hours ago.
```
E, [2015-05-06T13:54:26.489835 #27596] ERROR -- : Erb template /home/user/.berkshelf/cookbooks/apache2-31f7022f727db066bea28a967df22c54f5291f3b/templates/default/apache2.conf.erb has a syntax error:
E, [2015-05-06T13:54:26.489912 #27596] ERROR -- : /home/user/.berkshelf/cookbooks/apache2-31f7022f727db066bea28a967df22c54f5291f3b/templates/default/apache2.conf.erb:171: syntax error, unexpected keyword_end, expecting end-of-input
E, [2015-05-06T13:54:26.489959 #27596] ERROR -- : '; end
E, [2015-05-06T13:54:26.489986 #27596] ERROR -- :       ^
E, [2015-05-06T13:54:26.493629 #27596] ERROR -- : Ridley::Errors::CookbookSyntaxError: Invalid template files in cookbook: apache2 (3.0.1).
```

It's related with #349.
We need to delete end keyword.
