### PR TITLE
force log directory creation to be recursive

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -50,6 +50,7 @@ end
 
 directory node['apache']['log_dir'] do
   mode '0755'
+  recursive true
 end
 
 # perl is needed for the a2* scripts


### PR DESCRIPTION
Right now its not recursive and causes errors if the parent directories aren't created