### PR TITLE
add note about mod_fastcgi in Ubuntu 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,9 @@ mod\_fastcgi
 
 Install the fastcgi package and enable the module.
 
+Note: In Ubuntu 14.04, the `libapache2-mod-fastcgi` module is not available by default due to the [Multiverse](https://help.ubuntu.com/community/Repositories/Ubuntu) repositories.
+You need to enable the multiverse repositories either from `/etc/apt/sources.list` or use the `apt` cookbook.
+
 Only work on Debian/Ubuntu
 
 mod\_fcgid


### PR DESCRIPTION
Added a note in README to inform cookbook users that `libapache2-mod-fastcgi` requires [multiverse](http://packages.ubuntu.com/search?keywords=libapache2-mod-fastcgi) repositories in order to get installed.