### PR TITLE
Allow to use combined attribute for ports.conf

### DIFF
--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -25,14 +25,7 @@ describe 'apache2::default' do
           end
 
           it "installs package #{property[:apache][:package]}" do
-            case platform
-            when 'freebsd'
-              expect(chef_run).to install_freebsd_package(property[:apache][:package])
-            when 'amazon', 'fedora', 'redhat', 'centos'
-              expect(chef_run).to install_yum_package(property[:apache][:package])
-            else
-              expect(chef_run).to install_package(property[:apache][:package])
-            end
+            expect(chef_run).to install_package(property[:apache][:package])
           end
 
           it "creates #{property[:apache][:log_dir]} directory" do

--- a/spec/modules/mod_php5_spec.rb
+++ b/spec/modules/mod_php5_spec.rb
@@ -21,10 +21,9 @@ describe 'apache2::mod_php5' do
           pkg = 'php'
           pkg = 'php53' if version.to_f < 6.0
           it "installs package #{pkg}" do
-            expect(chef_run).to install_yum_package(pkg)
-            expect(chef_run).to_not install_yum_package("not_#{pkg}")
+            expect(chef_run).to install_package(pkg)
           end
-          let(:package) { chef_run.yum_package(pkg) }
+          let(:package) { chef_run.package(pkg) }
           it "triggers a notification by #{pkg} package install to execute[generate-module-list]" do
             expect(package).to notify('execute[generate-module-list]').to(:run)
             expect(package).to_not notify('execute[generate-module-list]').to(:nothing)


### PR DESCRIPTION
Instead of requiring to use the same set of ports on all configured addresses, we
allow to configure an explicit list of address:port pairs to listen on.

This will make it possible have setups listening on e.g.

  10.10.0.1:80
  10.10.0.2:443

without also listening on 10.10.0.1:443 or 10.10.0.2:80.

I know this is still lacking tests, I just would like to get some feedback first on whether you would consider this patch for inclusion. We are using it locally for installing apache2 as proxy in front of our OpenStack setup.