### PR TITLE
Restart apache that might be broken because mod_headers is not enabled.

### DIFF
--- a/recipes/mod_headers.rb
+++ b/recipes/mod_headers.rb
@@ -17,4 +17,6 @@
 # limitations under the License.
 #
 
-apache_module 'headers'
+apache_module 'headers' do
+      restart true
+end


### PR DESCRIPTION
Issue-376: Fixes a broken apache installation if mod_headers not being
enabled is the only reason for apache not starting.

mod_headers is also not included in the attribute,

apache2.default_modues;

although it should be, this patch puts control into the hands of the
consumer of apache2::mod_headers.