### PR TITLE
Mod_cloudflare yum support

### DIFF
--- a/recipes/mod_cloudflare.rb
+++ b/recipes/mod_cloudflare.rb
@@ -17,14 +17,26 @@
 # limitations under the License.
 #
 
-apt_repository 'cloudflare' do
-  uri 'http://pkg.cloudflare.com'
-  distribution node['lsb']['codename']
-  components ['main']
-  key 'http://pkg.cloudflare.com/pubkey.gpg'
-  action :add
-end
-
-package 'libapache2-mod-cloudflare' do
-  notifies :restart, 'service[apache2]'
+case node['platform_family']
+when 'debian'
+  apt_repository 'cloudflare' do
+    uri 'http://pkg.cloudflare.com'
+    distribution node['lsb']['codename']
+    components ['main']
+    key 'http://pkg.cloudflare.com/pubkey.gpg'
+    action :add
+  end
+  package 'libapache2-mod-cloudflare'
+  apache_module 'cloudflare'
+when 'rhel', 'fedora'
+  yum_repository 'cloudflare' do
+    description 'CloudFlare Packages'
+    baseurl 'http://pkg.cloudflare.com/dists/$releasever/main/binary-$basearch'
+    gpgkey 'http://pkg.cloudflare.com/pubkey.gpg'
+    action :create
+  end
+  package 'mod_cloudflare'
+  apache_module 'cloudflare'
+else
+  Chef::Log.warn "apache::mod_cloudflare does not support #{node['platform_family']}; mod_cloudflare is not being installed"
 end

--- a/spec/modules/mod_cloudflare_spec.rb
+++ b/spec/modules/mod_cloudflare_spec.rb
@@ -1,6 +1,40 @@
 require 'spec_helper'
 
-supported_platforms
+platforms = supported_platforms.select { |key, _| %w(debian ubuntu redhat centos fedora).include?(key) }
 
 describe 'apache2::mod_cloudflare' do
+  platforms.each do |platform, versions|
+    versions.each do |version|
+      context "on #{platform.capitalize} #{version}" do
+        let(:chef_run) do
+          @chef_run
+        end
+
+        property = load_platform_properties(:platform => platform, :platform_version => version)
+
+        before(:context) do
+          @chef_run = ChefSpec::SoloRunner.new(:platform => platform, :version => version)
+          stub_command("#{property[:apache][:binary]} -t").and_return(true)
+          @chef_run.converge(described_recipe)
+        end
+
+        if %w(debian ubuntu).include?(platform)
+          pkg = 'libapache2-mod-cloudflare'
+          it "installs package #{pkg}" do
+            expect(chef_run).to install_package(pkg)
+            expect(chef_run).to_not install_package("not_#{pkg}")
+          end
+        end
+        if %w(redhat centos fedora).include?(platform)
+          pkg = 'mod_cloudflare'
+          it "installs package #{pkg}" do
+            expect(chef_run).to install_package(pkg)
+            expect(chef_run).to_not install_package("not_#{pkg}")
+          end
+        end
+
+        it_should_behave_like 'an apache2 module', 'cloudflare', false
+      end
+    end
+  end
 end

--- a/spec/modules/mod_cloudflare_spec.rb
+++ b/spec/modules/mod_cloudflare_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 platforms = supported_platforms.select { |key, _| %w(debian ubuntu redhat centos fedora).include?(key) }
 
-describe 'apache2::mod_cloudflare' do
+# use the test fixture cookbook because we need apt_repository or yum_repository
+describe 'apache2_test::mod_cloudflare' do
   platforms.each do |platform, versions|
     versions.each do |version|
       context "on #{platform.capitalize} #{version}" do

--- a/test/fixtures/cookbooks/apache2_test/metadata.rb
+++ b/test/fixtures/cookbooks/apache2_test/metadata.rb
@@ -7,9 +7,11 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
 depends          'apache2'
+depends          'apt'
 depends          'jpackage'
 depends          'openldap'
 depends          'tomcat'
+depends          'yum'
 depends          'yum-epel'
 
 recipe           'apache2_test::default', 'Test example for default recipe'

--- a/test/fixtures/cookbooks/apache2_test/recipes/mod_cloudflare.rb
+++ b/test/fixtures/cookbooks/apache2_test/recipes/mod_cloudflare.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: apache2_test
+# Recipe:: mod_cloudflare
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'apache2::mod_cloudflare'


### PR DESCRIPTION
This adds yum support to the mod_cloudflare recipe, and also creates Chefspec tests for it.  Since the apt and yum cookbooks are not specified as dependencies in the main metadata.rb, we're getting the tests to pass by using the apache2_test cookbook.  Whether the apt and yum cookbooks should be added to the main metadata.rb as dependencies is up to you.