### PR TITLE
Fix for NameError in mod_proxy_html.rb

### DIFF
--- a/recipes/mod_proxy_html.rb
+++ b/recipes/mod_proxy_html.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-if node['apache']['version'] != '2.4' && platform_family == 'debian'
+if node['apache']['version'] != '2.4' && node[:platform_family] == 'debian'
   package 'libapache2-mod-proxy-html'
 end
 


### PR DESCRIPTION
Without this change, using this recipe results in:

NameError
---------
No resource, method, or local variable named `platform_family' for `Chef::Recipe "mod_proxy_html"'