### PR TITLE
Do not install an extra mod_ssl package on SUSE Linux Enterprise

### DIFF
--- a/recipes/mod_ssl.rb
+++ b/recipes/mod_ssl.rb
@@ -23,8 +23,10 @@ end
 include_recipe 'apache2::default'
 
 if platform_family?('rhel', 'fedora', 'suse')
-  package node['apache']['mod_ssl']['pkg_name'] do
-    notifies :run, 'execute[generate-module-list]', :immediately
+  if 'suse' != node['platform']
+    package node['apache']['mod_ssl']['pkg_name'] do
+      notifies :run, 'execute[generate-module-list]', :immediately
+    end
   end
 
   file "#{node['apache']['dir']}/conf.d/ssl.conf" do


### PR DESCRIPTION
This fixes for me: https://github.com/svanzoest-cookbooks/apache2/issues/385

Btw. I can not find any mod_ssl package on openSUSE 13.2. mod_ssl is installed with the normal apache2 package. What openSUSE platform are you testing on, that requires an additional mod_ssl package to be installed?