### PR TITLE
fix for #376

### DIFF
--- a/recipes/mod_headers.rb
+++ b/recipes/mod_headers.rb
@@ -17,4 +17,6 @@
 # limitations under the License.
 #
 
-apache_module 'headers'
+apache_module 'headers' do
+  restart true
+end


### PR DESCRIPTION
This should trigger a restart if the mod_headers recipe is included in the runlist (assuming it is not already broken by a previously borked install of mod_headers). Does this solve the problem?