### PR TITLE
Fixed attributes for SuSE

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -65,9 +65,8 @@ default['apache']['version'] =
     node['platform_version'].to_f >= 18 ? '2.4' : '2.2'
   when 'suse'
     case node['platform']
-    when 'opensuse'
-      node['platform_version'].to_f >= 13.1 ? '2.4' : '2.2'
-      # FIXME: when "suse" for SLES
+    when 'suse'
+      node['platform_version'].to_f >= 12.1 ? '2.4' : '2.2'
     else
       '2.4'
     end

--- a/attributes/mod_php5.rb
+++ b/attributes/mod_php5.rb
@@ -18,6 +18,7 @@
 
 default['apache']['mod_php5']['install_method'] = 'package'
 default['apache']['mod_php5']['so_filename'] = 'libphp5.so'
+default['apache']['mod_php5']['so_filename'] = 'mod_php5.so' if node['platform_family'] == 'suse'
 
 if node['platform'] == 'amazon' && node['apache']['version'] == '2.4'
   default['apache']['mod_php5']['so_filename'] = 'libphp.so'


### PR DESCRIPTION
I have made some fixed for the cookbook when run on SLES:
  - The node['apache']['mod_php5']['so_filename'] attribute doesnt work with SLES, because the PHP module is called mod_php.so not libphp.so.   
  - The attribute node['apache2]['version']  does not work with SLES11 right now because it only has apache2.2 and the cookbook installs a httpd.conf for apache2.4. platform? does not support 'opensuse' only 'suse' and the apache 2.4 package is available from 12.1 upwards.
