### PR TITLE
Fixed attributes for correct PIDfile on SuSE

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -135,10 +135,10 @@ when 'suse', 'opensuse'
   default['apache']['cache_dir']   = '/var/cache/apache2'
   default['apache']['run_dir']     = '/var/run/httpd'
   default['apache']['lock_dir']    = '/var/run/httpd'
-  if node['platform_version'].to_f >= 6
-    default['apache']['pid_file']    = '/var/run/httpd/httpd.pid'
-  else
+  if node['platform_version'].to_f > 11.4
     default['apache']['pid_file']    = '/var/run/httpd.pid'
+  else
+    default['apache']['pid_file']    = '/var/run/httpd2.pid'
   end
   default['apache']['lib_dir']     = node['kernel']['machine'] =~ /^i[36]86$/ ? '/usr/lib/apache2' : '/usr/lib64/apache2'
   default['apache']['libexec_dir'] = node['apache']['lib_dir']


### PR DESCRIPTION
If you want to start/stop the apache2 server on SLES11/12 with apache2ctl the pid files have to be in /var/run/httpd2.pid. 

So if I start the apache2 server with apache2ctl and want to stop it with /etc/init.d/apache2 it will fail, and vice versa.

This is because the pidfile is hardcoded in the /etc/init.d/apache2 script

_/etc/init.d/apache2_
```
pname=apache2
: ${sysconfdir:=/etc/$pname}
: ${apache_link:=/usr/sbin/httpd2}
: ${sysconfig_apache:=/etc/sysconfig/$pname}
: ${pidfile:=/var/run/httpd2.pid}
: ${logdir:=/var/log/$pname}
: ${homedir:=/var/lib/$pname}
``` 