### PR TITLE
Properly set ServerLimit on 2.4

### DIFF
--- a/templates/default/mods/mpm_prefork.conf.erb
+++ b/templates/default/mods/mpm_prefork.conf.erb
@@ -9,6 +9,7 @@
   StartServers           <%= node['apache']['prefork']['startservers'] %>
   MinSpareServers        <%= node['apache']['prefork']['minspareservers'] %>
   MaxSpareServers        <%= node['apache']['prefork']['maxspareservers'] %>
+  ServerLimit            <%= node['apache']['prefork']['serverlimit'] %>
   MaxRequestWorkers      <%= node['apache']['prefork']['maxrequestworkers'] %>
   MaxConnectionsPerChild <%= node['apache']['prefork']['maxconnectionsperchild'] %>
  <% else -%>


### PR DESCRIPTION
ServerLimit was not set for apache 2.4. I assume that was an omission, but perhaps not. We have hosts that need > 256 `MaxRequestWorkers`, which is the apache compile time default for `ServerLimit`.