### PR TITLE
Restart apache on mod_proxy install [ubuntu 12.04]

### DIFF
--- a/recipes/mod_proxy.rb
+++ b/recipes/mod_proxy.rb
@@ -19,4 +19,7 @@
 
 apache_module 'proxy' do
   conf true
+  if node['platform'] == 'ubuntu' && node['platform_version'].to_f == 12.04
+    restart true
+  end
 end


### PR DESCRIPTION
Seems that there are some issues that reload doesn't solve when configuring mod_proxy:

* https://mail-archives.apache.org/mod_mbox/httpd-users/201206.mbox/%3CCEC4814545B4C00A1D7CDFF2@Ximines.local%3E
* http://www.scriptscoop.net/t/7692fe379dfe/apache-httpd-error-proxy-ap-get-scoreboard-lb-with-proxypass.html

This resolves the issue on ubuntu 12.04, which is the only platform on which i've noticed the problem.