### PR TITLE
Remove forced deflate Module

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -345,7 +345,7 @@ default['apache']['default_modules'] = %w(
   authz_host authz_user autoindex dir env mime negotiation setenvif
 )
 
-%w(log_config logio).each do |log_mod|
+%w(log_config logio deflate).each do |log_mod|
   default['apache']['default_modules'] << log_mod if %w(rhel fedora suse arch freebsd).include?(node['platform_family'])
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -84,9 +84,6 @@ unless platform_family?('debian')
     command "/usr/local/bin/apache2_module_conf_generate.pl #{node['apache']['lib_dir']} #{node['apache']['dir']}/mods-available"
     action :nothing
   end
-
-  # enable mod_deflate for consistency across distributions
-  include_recipe 'apache2::mod_deflate'
 end
 
 if platform_family?('freebsd')


### PR DESCRIPTION
For any distro but Debian mod_deflate is 'forced' upon the system without a chance to disable it or adapt the configuration.

Moving this to the "default_modules" in the attributes should do the same, but allows me to disable it.

