### PR TITLE
swat integration tests for apache2 cookbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -138,6 +138,11 @@ suites:
   attributes:
     machine_fqdn: working.computers.biz
     machine_fqdn_as_hostname: true
+    sparrow:
+      plugin:
+        list: [
+            'swat-apache2-cookbook'
+        ]
   run_list:
   - recipe[fqdn]
   - recipe[apache2_test::setup]
@@ -148,10 +153,4 @@ suites:
     'centos-6.5',
     'debian-7.6'
   ]
-  attributes:
-    sparrow:
-      plugin:
-        list: [
-            'swat-apache2-cookbook'
-        ]
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -145,7 +145,8 @@ suites:
   - recipe[apache2_test::basic_web_app]
   - recipe[sparrow]
   includes: [
-    'centos-6.5'
+    'centos-6.5',
+    'debian-7.6'
   ]
   attributes:
     sparrow:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -143,6 +143,14 @@ suites:
   - recipe[apache2_test::setup]
   - recipe[apache2_test::default]
   - recipe[apache2_test::basic_web_app]
+  - recipe[sparrow]
   includes: [
     'centos-6.5'
   ]
+  attributes:
+    sparrow:
+      plugin:
+        list: [
+            'swat-apache2-cookbook'
+        ]
+

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -134,3 +134,15 @@ suites:
   - recipe[apache2_test::basic_web_app]
   - recipe[apache2_test::broken_conf]
   - recipe[apache2_test::modules]
+- name: swat
+  attributes:
+    machine_fqdn: working.computers.biz
+    machine_fqdn_as_hostname: true
+  run_list:
+  - recipe[fqdn]
+  - recipe[apache2_test::setup]
+  - recipe[apache2_test::default]
+  - recipe[apache2_test::basic_web_app]
+  includes: [
+    'centos-6.5'
+  ]

--- a/Berksfile
+++ b/Berksfile
@@ -7,6 +7,7 @@ group :integration do
   cookbook 'yum', '~> 3.8.2'
   cookbook 'zypper', '~> 0.2.1'
   cookbook 'pacman', '~> 1.1.1'
+  cookbook 'sparrow'  
   cookbook 'fqdn', :git => 'https://github.com/drpebcak/fqdn-cookbook.git'
 end
 

--- a/Berksfile
+++ b/Berksfile
@@ -7,7 +7,7 @@ group :integration do
   cookbook 'yum', '~> 3.8.2'
   cookbook 'zypper', '~> 0.2.1'
   cookbook 'pacman', '~> 1.1.1'
-  cookbook 'sparrow', '~> 0.0.5'  
+  cookbook 'sparrow', '~> 0.0.5'
   cookbook 'fqdn', :git => 'https://github.com/drpebcak/fqdn-cookbook.git'
 end
 

--- a/Berksfile
+++ b/Berksfile
@@ -7,7 +7,7 @@ group :integration do
   cookbook 'yum', '~> 3.8.2'
   cookbook 'zypper', '~> 0.2.1'
   cookbook 'pacman', '~> 1.1.1'
-  cookbook 'sparrow'  
+  cookbook 'sparrow', '~> 0.0.5'  
   cookbook 'fqdn', :git => 'https://github.com/drpebcak/fqdn-cookbook.git'
 end
 

--- a/Berksfile
+++ b/Berksfile
@@ -7,7 +7,7 @@ group :integration do
   cookbook 'yum', '~> 3.8.2'
   cookbook 'zypper', '~> 0.2.1'
   cookbook 'pacman', '~> 1.1.1'
-  cookbook 'sparrow', '~> 0.0.5'
+  cookbook 'sparrow', '~> 0.0.8'
   cookbook 'fqdn', :git => 'https://github.com/drpebcak/fqdn-cookbook.git'
 end
 

--- a/test/integration/swat/bash/swat_test.bash
+++ b/test/integration/swat/bash/swat_test.bash
@@ -1,29 +1,12 @@
-yum install perl-Test-Harness git -y -q
-
-which cpanm 1>/dev/null || curl -k -L http://cpanmin.us/ -o /usr/bin/cpanm
-
-chmod +x /usr/bin/cpanm
-
-which cpanm 1>/dev/null || exit 1
-
-export PATH=$PATH:/usr/local/bin/
-
-cpanm Sparrow || exit 1
+PATH=$PATH:/usr/local/bin/
 
 which sparrow 1>/dev/null || exit 1
-
-# sparrow plg remove swat-apache2-cookbook
-echo 'swat-apache2-cookbook https://github.com/melezhik/swat-apache2-cookbook.git' > ~/sparrow.list
-
-sparrow index update
-
-sparrow plg install private@swat-apache2-cookbook
 
 sparrow project create foo
 
 sparrow check add foo apache
 
-sparrow check set foo apache -p private@swat-apache2-cookbook -u `hostname -f`
+sparrow check set foo apache -p swat-apache2-cookbook -u `hostname -f`
 
 landing_page_line='Hello World' \
 match_l=300 \

--- a/test/integration/swat/bash/swat_test.bash
+++ b/test/integration/swat/bash/swat_test.bash
@@ -6,7 +6,7 @@ sparrow project create foo
 
 sparrow check add foo apache
 
-sparrow check set foo apache -p swat-apache2-cookbook -u `hostname -f`
+sparrow check set foo apache swat-apache2-cookbook `hostname -f`
 
 landing_page_line='Hello World' \
 match_l=300 \

--- a/test/integration/swat/bash/swat_test.bash
+++ b/test/integration/swat/bash/swat_test.bash
@@ -1,4 +1,4 @@
-yum install perl-Test-Harness -y -q
+yum install perl-Test-Harness git -y -q
 
 which cpanm 1>/dev/null || curl -k -L http://cpanmin.us/ -o /usr/bin/cpanm
 
@@ -13,17 +13,21 @@ cpanm Sparrow || exit 1
 which sparrow 1>/dev/null || exit 1
 
 # sparrow plg remove swat-apache2-cookbook
+echo 'swat-apache2-cookbook https://github.com/melezhik/swat-apache2-cookbook.git' > ~/sparrow.list
+
 sparrow index update
 
-sparrow plg install swat-apache2-cookbook
+sparrow plg install private@swat-apache2-cookbook
 
 sparrow project create foo
 
 sparrow check add foo apache
 
-sparrow check set foo apache -p swat-apache2-cookbook -u `hostname -f`
+sparrow check set foo apache -p private@swat-apache2-cookbook -u `hostname -f`
 
-match_l=300 sparrow check run foo apache
+landing_page_line='Hello World' \
+match_l=300 \
+sparrow check run foo apache
 
 st=$?
 

--- a/test/integration/swat/bash/swat_test.bash
+++ b/test/integration/swat/bash/swat_test.bash
@@ -1,0 +1,35 @@
+yum install perl-Test-Harness -y -q
+
+which cpanm 1>/dev/null || curl -k -L http://cpanmin.us/ -o /usr/bin/cpanm
+
+chmod +x /usr/bin/cpanm
+
+which cpanm 1>/dev/null || exit 1
+
+export PATH=$PATH:/usr/local/bin/
+
+cpanm Sparrow || exit 1
+
+which sparrow 1>/dev/null || exit 1
+
+# sparrow plg remove swat-apache2-cookbook
+sparrow index update
+
+sparrow plg install swat-apache2-cookbook
+
+sparrow project create foo
+
+sparrow check add foo apache
+
+sparrow check set foo apache -p swat-apache2-cookbook -u `hostname -f`
+
+match_l=300 sparrow check run foo apache
+
+st=$?
+
+# find /root/.swat/.cache/ -type f -exec tail -n +1 {} \;
+
+exit $st
+
+     
+


### PR DESCRIPTION
Hi  @svanzoest !

I have just created an [integration tests](https://sparrowhub.org/info/swat-apache2-cookbook?v=0.000006) for apache2cookbook using [swat](https://swatpm.org/) -  DSL for rapid web tests development. 

To run them:

```      
$ kitchen test swat
```
 
