### PR TITLE
resolve reload problem on rhel based systems using apache2.2

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -211,7 +211,7 @@ service 'apache2' do
   case node['platform_family']
   when 'rhel'
     restart_command "/sbin/service #{apache_service_name} restart && sleep 1" if node['apache']['version'] == '2.2'
-    reload_command "/sbin/service #{apache_service_name} graceful"
+    reload_command "/sbin/service #{apache_service_name} graceful && sleep 1" if node['apache']['version'] == '2.2'
   when 'debian'
     provider Chef::Provider::Service::Debian
   when 'arch'


### PR DESCRIPTION
Ref: https://github.com/svanzoest-cookbooks/apache2/issues/259

Added `&& sleep 1' if node['apache']['version'] == '2.2'` to RHEL reload