### PR TITLE
Make sure Upstart is used on Ubuntu 14.04

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -214,6 +214,10 @@ service 'apache2' do
     reload_command "/sbin/service #{apache_service_name} graceful"
   when 'debian'
     provider Chef::Provider::Service::Debian
+  when 'ubuntu'
+    if node["platform_version"].to_f >= 14.04
+      provider Chef::Provider::Service::Upstart
+    end
   when 'arch'
     service_name apache_service_name
   end


### PR DESCRIPTION
Add the Chef::Provider::Service::Upstart provider for Ubuntu 14.04