### PR TITLE
Make mod_fastcgi package install the default everywhere

### DIFF
--- a/attributes/mod_fastcgi.rb
+++ b/attributes/mod_fastcgi.rb
@@ -3,6 +3,7 @@
 # Attributes:: mod_fastcgi
 #
 # Copyright 2013, Chef Software, Inc.
+# Copyright 2016, Alexander van Zoest
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,3 +20,18 @@
 
 default['apache']['mod_fastcgi']['download_url'] = 'http://www.fastcgi.com/dist/mod_fastcgi-current.tar.gz'
 default['apache']['mod_fastcgi']['install_method'] = 'package'
+default['apache']['mod_fastcgi']['package'] =
+  case node['platform_family']
+    when 'debian'
+     'libapache2-mod-fastcgi'
+    when 'rhel'
+      package 'mod_fastcgi'
+    when 'freebsd'
+       if node['apache']['version'] == '2.4'
+         'ap24-mod_fastcgi'
+       else
+         'ap22-mod_fastcgi'
+       end
+    else
+      package 'mod_fastcgi'
+    end

--- a/recipes/mod_fastcgi.rb
+++ b/recipes/mod_fastcgi.rb
@@ -17,22 +17,19 @@
 # limitations under the License.
 #
 
-if platform_family?('debian')
-  if node['apache']['mod_fastcgi']['install_method'] == 'source'
+if node['apache']['mod_fastcgi']['install_method'] == 'package'
+  package node['apache']['mod_fastcgi']['package']
+else
+  if platform_family?('debian')
     package 'build-essential'
     package node['apache']['devel_package']
-  else
-    package 'libapache2-mod-fastcgi'
-  end
-elsif platform_family?('rhel')
-  %W(gcc make libtool #{node['apache']['devel_package']} apr-devel apr).each do |package|
+  elsif platform_family?('rhel')
+    %W(gcc make libtool #{node['apache']['devel_package']} apr-devel apr).each do |package|
     yum_package package do
       action :upgrade
     end
   end
-end
 
-if platform_family?('rhel') || (platform_family?('debian') && node['apache']['mod_fastcgi']['install_method'] == 'source')
   src_filepath = "#{Chef::Config['file_cache_path']}/fastcgi.tar.gz"
   remote_file 'download fastcgi source' do
     source node['apache']['mod_fastcgi']['download_url']
@@ -56,10 +53,6 @@ if platform_family?('rhel') || (platform_family?('debian') && node['apache']['mo
       cp Makefile.AP2 Makefile &&
       make top_dir=#{top_dir} && make install top_dir=#{top_dir}
     EOH
-  end
-elsif platform_family?('freebsd')
-  if node['apache']['mod_fastcgi']['install_method'] == 'package'
-    package 'ap24-mod_fastcgi'
   end
 end
 


### PR DESCRIPTION
The fastcgi recipe still used `source` as the default on the `rhel` platform family. 
See #415 