### PR TITLE
Correct fastcgi package for rhel

### DIFF
--- a/attributes/mod_fastcgi.rb
+++ b/attributes/mod_fastcgi.rb
@@ -25,7 +25,7 @@ default['apache']['mod_fastcgi']['package'] =
     when 'debian'
      'libapache2-mod-fastcgi'
     when 'rhel'
-      package 'mod_fcgid'
+     'mod_fcgid'
     when 'freebsd'
        if node['apache']['version'] == '2.4'
          'ap24-mod_fastcgi'

--- a/attributes/mod_fastcgi.rb
+++ b/attributes/mod_fastcgi.rb
@@ -25,7 +25,7 @@ default['apache']['mod_fastcgi']['package'] =
     when 'debian'
      'libapache2-mod-fastcgi'
     when 'rhel'
-      package 'mod_fastcgi'
+      package 'mod_fcgid'
     when 'freebsd'
        if node['apache']['version'] == '2.4'
          'ap24-mod_fastcgi'


### PR DESCRIPTION
I found the correct package for the rhel platform family to be mod_fcgid.