### PR TITLE
Allow auto-conversion if either of node['apache']['listen_ports'] or …

### DIFF
--- a/libraries/listen.rb
+++ b/libraries/listen.rb
@@ -31,7 +31,7 @@ module Apache2
     private_class_method
 
     def self.converted_listen_ports_and_addresses(node)
-      return [] unless node['apache']['listen_ports'] && node['apache']['listen_addresses']
+      return [] unless node['apache']['listen_ports'] || node['apache']['listen_addresses']
       Chef::Log.warn "node['apache']['listen_ports'] and node['apache']['listen_addresses'] are deprecated in favor of node['apache']['listen']. Please adjust your cookbooks"
 
       node['apache']['listen_addresses'].uniq.each_with_object([]) do |address, listen|


### PR DESCRIPTION
…node['apache']['listen_addresses'] are set rather than '&&'. This ensures conversion occurs if only one of the two is set.