### PR TITLE
Fix uniq for nil:NilClass error introduced in 3.2.2

### DIFF
--- a/libraries/listen.rb
+++ b/libraries/listen.rb
@@ -34,8 +34,8 @@ module Apache2
       return [] unless node['apache']['listen_ports'] || node['apache']['listen_addresses']
       Chef::Log.warn "node['apache']['listen_ports'] and node['apache']['listen_addresses'] are deprecated in favor of node['apache']['listen']. Please adjust your cookbooks"
 
-      node['apache']['listen_addresses'].uniq.each_with_object([]) do |address, listen|
-        node['apache']['listen_ports'].uniq.each do |port|
+      (node['apache']['listen_addresses'] || []).uniq.each_with_object([]) do |address, listen|
+        (node['apache']['listen_ports'] || []).uniq.each do |port|
           listen << "#{address}:#{port}"
         end
       end

--- a/libraries/listen.rb
+++ b/libraries/listen.rb
@@ -34,8 +34,9 @@ module Apache2
       return [] unless node['apache']['listen_ports'] || node['apache']['listen_addresses']
       Chef::Log.warn "node['apache']['listen_ports'] and node['apache']['listen_addresses'] are deprecated in favor of node['apache']['listen']. Please adjust your cookbooks"
 
-      (node['apache']['listen_addresses'] || []).uniq.each_with_object([]) do |address, listen|
-        (node['apache']['listen_ports'] || []).uniq.each do |port|
+      # Defaults to * for addresses or 80 / 443 for ports if not specified
+      (node['apache']['listen_addresses'] || %w(*)).uniq.each_with_object([]) do |address, listen|
+        (node['apache']['listen_ports'] || %w(80 443)).uniq.each do |port|
           listen << "#{address}:#{port}"
         end
       end

--- a/test/fixtures/cookbooks/apache2_test/attributes/default.rb
+++ b/test/fixtures/cookbooks/apache2_test/attributes/default.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+default['apache']['listen_ports'] = ['80']
 default['apache_test']['auth_username'] = 'bork'
 default['apache_test']['auth_password'] = 'secret'
 default['apache_test']['cache_expiry_seconds'] = 60


### PR DESCRIPTION
- Add default values for listen_ports and listen_addresses
- Add attribute to test for the error introduced