### PR TITLE
CentOs 6 and HTTPD24 fixes 

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ source_url 'https://github.com/svanzoest-cookbooks/apache2/' if respond_to?(:sou
 license 'Apache 2.0'
 description 'Installs and configures all aspects of apache2 using Debian style symlinks with helper definitions'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.2.2'
+version '3.2.3'
 
 supports 'debian'
 supports 'ubuntu'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,8 +18,6 @@
 # limitations under the License.
 #
 
-apache_service_name = node['apache']['service_name']
-
 package 'apache2' do # ~FC009 only available in apt_package. See #388
   package_name node['apache']['package']
   default_release node['apache']['default_release'] unless node['apache']['default_release'].nil?
@@ -202,6 +200,8 @@ if node['apache']['default_site_enabled']
     enable node['apache']['default_site_enabled']
   end
 end
+
+apache_service_name = node['apache']['service_name']
 
 if node['platform_version'].to_f < 7.0 && node['apache']['package'] == 'httpd24'
     service 'apache2' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -207,7 +207,10 @@ service 'apache2' do
   service_name apache_service_name
   case node['platform_family']
   when 'rhel'
-    if node['platform_version'].to_f < 7.0
+    if node['platform_version'].to_f < 7.0 && node['apache']['package'] = 'httpd24'
+      restart_command "/sbin/service #{apache_service_name} restart && sleep 1"
+      reload_command "/sbin/service #{apache_service_name} reload && sleep 1"
+    else if node['platform_version'].to_f < 7.0
       restart_command "/sbin/service #{apache_service_name} restart && sleep 1"
       reload_command "/sbin/service #{apache_service_name} graceful && sleep 1"
     end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+apache_service_name = node['apache']['service_name']
+
 package 'apache2' do # ~FC009 only available in apt_package. See #388
   package_name node['apache']['package']
   default_release node['apache']['default_release'] unless node['apache']['default_release'].nil?
@@ -201,25 +203,30 @@ if node['apache']['default_site_enabled']
   end
 end
 
-apache_service_name = node['apache']['service_name']
-
-service 'apache2' do
-  service_name apache_service_name
-  case node['platform_family']
-  when 'rhel'
-    if node['platform_version'].to_f < 7.0 && node['apache']['package'] = 'httpd24'
-      restart_command "/sbin/service #{apache_service_name} restart && sleep 1"
-      reload_command "/sbin/service #{apache_service_name} reload && sleep 1"
-    else if node['platform_version'].to_f < 7.0
-      restart_command "/sbin/service #{apache_service_name} restart && sleep 1"
-      reload_command "/sbin/service #{apache_service_name} graceful && sleep 1"
+if node['platform_version'].to_f < 7.0 && node['apache']['package'] == 'httpd24'
+    service 'apache2' do
+        service_name apache_service_name
+        action :restart
+        supports [:start, :restart, :reload, :status]
     end
-  when 'debian'
-    provider Chef::Provider::Service::Debian
-  when 'arch'
-    service_name apache_service_name
-  end
-  supports [:start, :restart, :reload, :status]
-  action [:enable, :start]
-  only_if "#{node['apache']['binary']} -t", :environment => { 'APACHE_LOG_DIR' => node['apache']['log_dir'] }, :timeout => 10
+else
+
+    service 'apache2' do
+      service_name apache_service_name
+      case node['platform_family']
+      when 'rhel'
+        if node['platform_version'].to_f < 7.0
+            restart_command "/sbin/service #{apache_service_name} restart && sleep 1"
+            reload_command "/sbin/service #{apache_service_name} graceful && sleep 1"
+        end
+      when 'debian'
+        provider Chef::Provider::Service::Debian
+      when 'arch'
+        service_name apache_service_name
+      end
+      supports [:start, :restart, :reload, :status]
+      #action [:enable, :start]
+      action [:start]
+      only_if "#{node['apache']['binary']} -t", :environment => { 'APACHE_LOG_DIR' => node['apache']['log_dir'] }, :timeout => 10
+    end
 end


### PR DESCRIPTION
There were a few issues, and honestly I am a complete CHEF hack.  Hopefully this serves as a model for how to get this work between centOs6 ann httpd24.  The "graceful" command is just broken for this os/apache combination (relies on systemctl)  -and that is within the apache install.  I tried modifying theand reload command on the service and that didn't work either.  Surprisingly just removing thos extra lines seemed to clear it up.  I probably did something wrong - so if I have please let me know - but it seems working by my estimation.

T

For Issue: https://github.com/svanzoest-cookbooks/apache2/issues/423