### PR TITLE
Add option to configure custom log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ values are noted.
 * `node['apache']['keepaliverequests']` - Value for MaxKeepAliveRequests. Default is 100.
 * `node['apache']['keepalivetimeout']` - Value for the KeepAliveTimeout directive. Default is 5.
 * `node['apache']['sysconfig_additional_params']` - Additionals variables set in sysconfig file. Default is empty.
+* `node['apache']['log_level']` - Value for LogLevel directive. Default is 'warn'.
 * `node['apache']['default_modules']` - Array of module names. Can take "mod_FOO" or "FOO" as names, where FOO is the apache module, e.g. "`mod_status`" or "`status`".
 * `node['apache']['mpm']` - With apache.version 2.4, specifies what Multi-Processing Module to enable. Defaults to platform default, otherwise it is "prefork"
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -288,6 +288,7 @@ default['apache']['default_site_enabled'] = false
 default['apache']['default_site_port']    = '80'
 default['apache']['access_file_name'] = '.htaccess'
 default['apache']['default_release'] = nil
+default['apache']['log_level'] = 'warn'
 
 # Security
 default['apache']['servertokens']    = 'Prod'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -99,6 +99,7 @@ describe 'apache2::default' do
             )
             expect(chef_run).to render_file(property[:apache][:conf]).with_content(/AccessFileName[\s]*\.htaccess/)
             expect(chef_run).to render_file(property[:apache][:conf]).with_content(/Files ~ \"\^\\\.ht\"/)
+            expect(chef_run).to render_file(property[:apache][:conf]).with_content(/LogLevel warn/)
           end
 
           subject(:apacheconf) { chef_run.template(property[:apache][:conf]) }
@@ -293,6 +294,27 @@ describe 'apache2::default' do
             )
             expect(chef_run).to render_file(property[:apache][:conf]).with_content(/AccessFileName[\s]*\.customaccess/)
             expect(chef_run).to render_file(property[:apache][:conf]).with_content(/Files ~ \"\^\(\.cu\|\\\.ht\)\"/)
+          end
+        end
+
+        context 'with custom LogLevel' do
+          before(:context) do
+            @chef_run = ChefSpec::SoloRunner.new(:platform => platform, :version => version) do |node|
+              node.set['apache']['log_level'] = 'error'
+            end
+
+            stub_command("#{property[:apache][:binary]} -t").and_return(false)
+            @chef_run.converge(described_recipe)
+          end
+
+          it "creates #{property[:apache][:conf]}" do
+            expect(chef_run).to create_template(property[:apache][:conf]).with(
+              :source => 'apache2.conf.erb',
+              :owner => 'root',
+              :group => property[:apache][:root_group],
+              :mode =>  '0644'
+            )
+            expect(chef_run).to render_file(property[:apache][:conf]).with_content(/LogLevel error/)
           end
         end
 

--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -147,7 +147,7 @@ ErrorLog <%= node['apache']['log_dir'] %>/<%= node['apache']['error_log'] %>
 # Possible values include: debug, info, notice, warn, error, crit,
 # alert, emerg.
 #
-LogLevel warn
+LogLevel <%= node['apache']['log_level'] %>
 
 # COOK-1021: Dummy LoadModule directive to aid module installations
 #LoadModule dummy_module modules/mod_dummy.so

--- a/templates/default/default-site.conf.erb
+++ b/templates/default/default-site.conf.erb
@@ -40,7 +40,7 @@ NameVirtualHost *:<%= node['apache']['default_site_port'] %>
 
   # Possible values include: debug, info, notice, warn, error, crit,
   # alert, emerg.
-  LogLevel warn
+  LogLevel <%= node['apache']['log_level'] %>
 
   CustomLog <%= node['apache']['log_dir'] %>/<%= node['apache']['access_log'] %> combined
   ServerSignature On

--- a/test/integration/default/serverspec/localhost/default_spec.rb
+++ b/test/integration/default/serverspec/localhost/default_spec.rb
@@ -113,6 +113,7 @@ describe 'apache2::default' do
     expect(config).to contain %Q(ServerRoot "#{property[:apache][:dir]}")
     expect(config).to contain 'AccessFileName .htaccess'
     expect(config).to contain 'Files ~ "^\.ht"'
+    expect(config).to contain 'LogLevel warn'
     if property[:apache][:version] == '2.4'
       expect(config).to contain "IncludeOptional #{property[:apache][:dir]}/conf-enabled/*.conf"
       expect(config).to_not contain "Include #{property[:apache][:dir]}/conf.d/*.conf"


### PR DESCRIPTION
For the LogLevel, creating custom template is suggested as solution in https://github.com/svanzoest-cookbooks/apache2/issues/406 and I understand that default template needs to be clean and simple. 

However, if custom template is created in a wrapper cookbook and apache2 cookbook's default template get updated in the future, custom template in the wrapper cookbook needs to be updated in case the difference is only LogLevel part.

Updating template by `berks update apache2` would be less buggy workflow for the wrapper cookbook authors compared to manually copying and pasting the updated template from apache2 cookbook to the one in wrapper, then manually change LogLevel.

An example use case which is expected to get benefit from this PR can be found in [this wrapper](https://github.com/haapp/w_apache/blob/master/recipes/vhosts.rb#L17), and this wrapper is designed to utilize community cookbooks as much as possible including apache2.conf.erb from apache2.

The fact that [a candidate of web_app custom resource comes with log_level customizable via resource property (not by replacing web_app.conf.erb)](https://github.com/cyberswat/apache2/blob/81582afdd654691e2d338f4fca552845586c164e/providers/web_app.rb#L39) could support the idea of making LogLevel customizable via attribute not via replacing hardcorded template.

A decision may need to be made either: 
1. both [web_app.conf.erb](https://github.com/cyberswat/apache2/blob/81582afdd654691e2d338f4fca552845586c164e/templates/default/web_app.conf.erb#L5) and [apache2.conf.erb](https://github.com/joelhandwell/chef-apache2/blob/loglevel/templates/default/apache2.conf.erb#L150) to hardcord LogLevel or 
2. both of them to be customizable via custom resource property and node attribute. or
3. some other way thinking outside of the box

This PR suggests 2.
