### PR TITLE
Use plain php package for mod_php5 in Ubuntu 16.04

### DIFF
--- a/recipes/mod_php5.rb
+++ b/recipes/mod_php5.rb
@@ -27,7 +27,11 @@ end
 
 case node['platform_family']
 when 'debian'
-  package 'libapache2-mod-php5'
+  if node['lsb']['release'].to_f >= 16.04
+    package 'libapache2-mod-php'
+  else
+    package 'libapache2-mod-php5'
+  end
 when 'arch'
   package 'php-apache' do
     notifies :run, 'execute[generate-module-list]', :immediately


### PR DESCRIPTION
Ubuntu 16.04 has dropped the "5" from php packages mean php5 just becomes php now. php7 is now available with number specification.
