### PR TITLE
Allow for override of default-site.conf template

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -286,6 +286,8 @@ default['apache']['locale'] = 'C'
 default['apache']['sysconfig_additional_params'] = {}
 default['apache']['default_site_enabled'] = false
 default['apache']['default_site_port']    = '80'
+default['apache']['default_site_template'] = 'default-site.conf.erb'
+default['apache']['default_site_cookbook'] = 'apache2'
 default['apache']['access_file_name'] = '.htaccess'
 default['apache']['default_release'] = nil
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -196,7 +196,8 @@ end
 
 if node['apache']['default_site_enabled']
   web_app node['apache']['default_site_name'] do
-    template 'default-site.conf.erb'
+    template node['apache']['default_site_template']
+    cookbook node['apache']['default_site_cookbook']
     enable node['apache']['default_site_enabled']
   end
 end


### PR DESCRIPTION
These attributes will allow others to override the default site template from their wrapper cookbooks.
The **node['apache']['default_site_template']** attribute will allow users to override the template file, and the **node['apache']['default_site_cookbook']** will allow users to set the cookbook location of where the template file is located.