### PR TITLE
allow to reload web_app immediately via param for definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,8 @@ combine the template with enabling a site, see `web_app`.
 
 * `name` - Name of the site.
 * `enable` - Default true, which uses `a2ensite` to enable the site. If false, the site will be disabled with `a2dissite`.
+* `reload_speed` - Defaults to `:delayed` and can be set to `:immediately` to
+  reload apache service directly after web_app definition during the chef-run
 
 web\_app
 --------
@@ -603,6 +605,20 @@ the apache httpd directives defining the `VirtualHost` that would serve up "my_a
     web_app "my_app" do
        template 'web_app.conf.erb'
        server_name node['my_app']['hostname']
+    end
+``````
+
+If you need your web_app to be accessible during the chef-run and directly after
+you ran the definition `web_app`, you can set `reload_speed` to `:immediately`
+(which will immediately reload the apache2 service) instead of the default
+`:delayed` (which reloads your apache2 configuration at the end of the
+chef-run).
+
+``````
+    web_app "my_app" do
+       template 'web_app.conf.erb'
+       server_name node['my_app']['hostname']
+       reload_speed :immediately
     end
 ``````
 

--- a/definitions/web_app.rb
+++ b/definitions/web_app.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-define :web_app, :template => 'web_app.conf.erb', :local => false, :enable => true, :server_port => 80 do
+define :web_app, :template => 'web_app.conf.erb', :local => false, :enable => true, :server_port => 80, reload_speed: :delayed do
   application_name = params[:name]
 
   include_recipe 'apache2::default'
@@ -37,7 +37,7 @@ define :web_app, :template => 'web_app.conf.erb', :local => false, :enable => tr
       :params           => params
     )
     if ::File.exist?("#{node['apache']['dir']}/sites-enabled/#{application_name}.conf")
-      notifies :reload, 'service[apache2]', :delayed
+      notifies :reload, 'service[apache2]', params[:reload_speed]
     end
   end
 

--- a/test/fixtures/cookbooks/apache2_test/recipes/basic_web_app.rb
+++ b/test/fixtures/cookbooks/apache2_test/recipes/basic_web_app.rb
@@ -31,6 +31,14 @@ file "#{app_dir}/index.html" do
   action :create
 end
 
+web_app 'basic_immediate_webapp' do
+  cookbook 'apache2'
+  server_name node['hostname']
+  server_aliases [node['fqdn']]
+  docroot app_dir
+  reload_speed :immediately
+end
+
 web_app 'basic_webapp' do
   cookbook 'apache2'
   server_name node['hostname']


### PR DESCRIPTION
* Sometimes it's needed to immediately reload a web_app/apache2 to
continue the chef-run, since the webserver is lateron used. This patch
allows to set the reload_speed for the web_app definition (apache2
service) via the parameter :reload_speed. The default behaviour does not
change.