### PR TITLE
fixed typo in copyright year

### DIFF
--- a/definitions/apache_mod.rb
+++ b/definitions/apache_mod.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: apache2
 # Definition:: apache_mod
 #
-# Copyright 2008-20013, Chef Software, Inc.
+# Copyright 2008-2013, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION

Fixed typo in  definitions/apache_mod.rb "Copyright 2008-20013".