### PR TITLE
Ensure the lock_dir is owned by www-data for Apache 2.2 and 2.4 on Debian/Ubuntu

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -127,7 +127,7 @@ end
 
 directory node['apache']['lock_dir'] do
   mode '0755'
-  if node['platform_family'] == 'debian' && node['apache']['version'] == '2.2'
+  if node['platform_family'] == 'debian' && %(2.2 2.4).include?(node['apache']['version'])
     owner node['apache']['user']
   else
     owner 'root'


### PR DESCRIPTION
## Description

The default `apache2ctl` script for both Apache 2.2 and 2.4 creates the `lock_dir` in `/var/lock/apache2`. If the directory exists but is not owned by `www-data`, the script fails, similar to what is described in #310 and #312.

### Issues Resolved

This commit enhances the fix from #312 for Apache 2.4 in Debian/Ubuntu.

### Check List
- [ ] All tests pass. See https://github.com/svanzoest-cookbooks/apache2/blob/master/TESTING.md
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable